### PR TITLE
feat: support username claim suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - More prometheus metrics
 - More UX improvements
+- Allow appending a custom suffix to username claims via the
+  `LOGINAPP_USERNAME_CLAIM_SUFFIX` environment variable
 
 ## [v3.2.0] - 2020-11-25
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Loginapp supports three configuration formats:
 * Environment vars: each flag provides an environment var with
   'LOGINAPP_' prefix.
   Ex: '--oidc-client-secret' --> 'LOGINAPP_OIDC_CLIENT_SECRET'
+  A custom suffix can be appended to the username claim by setting the
+  `LOGINAPP_USERNAME_CLAIM_SUFFIX` environment variable.
 
 Configuration precedence: flags > environment vars > configuration file
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/fydrah/loginapp/pkg/client"
@@ -70,13 +71,18 @@ func (s *Server) ProcessCallback(w http.ResponseWriter, r *http.Request) (KubeUs
 		http.Error(w, msg, http.StatusInternalServerError)
 		return KubeUserInfo{}, fmt.Errorf(msg)
 	}
+	suffix := os.Getenv("LOGINAPP_USERNAME_CLAIM_SUFFIX")
+	username := usernameClaim.(string)
+	if suffix != "" {
+		username = username + suffix
+	}
 	log.Debugf("token issued with claims: %v", jsonClaims)
 	return KubeUserInfo{
 		IDToken:       rawIDToken,
 		RefreshToken:  token.RefreshToken,
 		RedirectURL:   s.Config.OIDC.Issuer.URL,
 		Claims:        jsonClaims,
-		UsernameClaim: usernameClaim.(string),
+		UsernameClaim: username,
 		AppConfig:     s.Config,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- allow appending custom suffix to username claim via LOGINAPP_USERNAME_CLAIM_SUFFIX
- document username claim suffix env var

## Testing
- `timeout 100s go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68990dfca914832583ac42da708c5eed